### PR TITLE
Upgrade to Java 21 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
             revJedis                : '3.3.0',
             revMockServerClient     : '5.12.0',
             revCommonsLang          : '3.12.0',
-            revLombok               : '1.18.24',
+            revLombok               : '1.18.30',
             revLucene               : '7.7.3',
             revSpectator            : '0.122.0',
             revOpenapi              : '1.6.+',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/orkes-conductor-queues/gradle/wrapper/gradle-wrapper.properties
+++ b/orkes-conductor-queues/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+


### PR DESCRIPTION
### Issue: Gradle build is not compatible with Java 18+

#### Solution: Lombok and Gradle upgrade for compatibility

Works with Java 17+

#### Details of the issues

###### Java version
[
<img width="848" alt="Java 21" src="https://github.com/codehackerr/orkes-queues/assets/5775870/9cc6b48c-2144-4aad-a274-5dd2e88375d4">
](url)

###### Lombok issue
<img width="1478" alt="Lombok Failure with Java 18+" src="https://github.com/codehackerr/orkes-queues/assets/5775870/83d00e85-c631-4ac3-bbe8-f5c356567e25">

https://github.com/projectlombok/lombok/issues/3393

###### Gradle compatibility issue
<img width="1465" alt="Gradle 7 6 incompatibility" src="https://github.com/codehackerr/orkes-queues/assets/5775870/c92adacf-8536-4e26-9db8-129e81beaf7c">

https://docs.gradle.org/current/userguide/compatibility.html

